### PR TITLE
Added an event that triggers when the AppModel is loaded

### DIFF
--- a/app_model.php
+++ b/app_model.php
@@ -454,3 +454,5 @@
 		 */
 		public $tablePrefix = 'core_';
 	}
+	
+	EventCore::trigger(new stdClass(), 'loadAppModel');

--- a/core/events/libs/app_events.php
+++ b/core/events/libs/app_events.php
@@ -82,6 +82,18 @@
 		 * They will be loaded when 'AppController' is included, before it runs.
 		 */
 		public function onLoadAppController(){}
+		
+
+		/**
+		 * Load up some of your own 'AppModels' so that you can create a base
+		 * class for a collection of plugins. Say you have a few plugins that all
+		 * use a specific database you can create 'CustomGlobalAppModel' that
+		 * extends 'AppModel' and then have all the 'PluginAppModels'
+		 * extend your 'CustomGlobalAppModel'
+		 *
+		 * They will be loaded when 'AppModel' is included, before it runs.
+		 */
+		public function onLoadAppModel(){}
 
 		/**
 		 * Add database connections from your plugins with this trigger.


### PR DESCRIPTION
onLoadAppController is not triggered when you're inside the testsuite, this will throw class not exists errors when testing models. Added an onLoadAppModel.
